### PR TITLE
Hs 5 add dynamic firewalls

### DIFF
--- a/hpotter/plugins/ContainerThread.py
+++ b/hpotter/plugins/ContainerThread.py
@@ -150,7 +150,7 @@ class ContainerThread(threading.Thread):
 
         self.save_connection()
 
-        # TODO: startup dynamic iptables rules code here.
+        # startup dynamic iptables rules code here.
 
         rules = self.create_rules(self.source.getsockname()[0], self.source.getsockname()[1],
                                   self.dest.getsockname()[0], self.dest.getsockname()[1])
@@ -170,10 +170,9 @@ class ContainerThread(threading.Thread):
         logger.debug('Joining thread2')
         self.thread2.join()
 
-        # TODO: shutdown dynamic iptables
+        # shutdown dynamic iptables
 
         self.end_dynamic_firewall(rules)
-
 
         self.dest.close()
         self.stop_and_remove()

--- a/hpotter/plugins/ContainerThread.py
+++ b/hpotter/plugins/ContainerThread.py
@@ -75,6 +75,8 @@ class ContainerThread(threading.Thread):
 
     def create_rules(self, src_ip, src_port, dest_ip, dest_port):
         """
+        TODO: Create chain named after container hash by getting the 'id' value from the container
+        TODO: Create rule that will have the forward chain read the rule in the chain named after the container hash
         Creates rules for the dynamic firewall
             1) Allow the attacker to send packets to the container
             2) Allow the attacker to receive packets from the container

--- a/hpotter/plugins/ContainerThread.py
+++ b/hpotter/plugins/ContainerThread.py
@@ -89,7 +89,7 @@ class ContainerThread(threading.Thread):
         :param src_ip: Attacker's IP
         :param src_port: Attacker's port
         :param dest_ip: Container's IP
-        :param dest_port: Cotainer's Port
+        :param dest_port: Container's Port
         :return rule[]: Rule array returned for usage in end_dynamic_firewall()
         """
 
@@ -113,7 +113,7 @@ class ContainerThread(threading.Thread):
 
         drop_rule = iptc.Rule()
         drop_rule.src = dest_ip
-        drop_rule.dst = "*"
+        drop_rule.dst = "!" + src_ip
         drop_rule.create_target("DROP")
         drop_match = drop_rule.create_match("tcp")
         drop_match.sport = dest_port
@@ -152,7 +152,8 @@ class ContainerThread(threading.Thread):
 
         # TODO: startup dynamic iptables rules code here.
 
-        rules_to_remove = self.start_dynamic_firewall(self.source.getsockname()[0], self.dest.getsockname()[0])
+        rules_to_remove = self.start_dynamic_firewall(self.source.getsockname()[0], self.source.getsockname()[1],
+                                                      self.dest.getsockname()[0], self.dest.getsockname()[1])
 
         logger.debug('Starting thread1')
         self.thread1 = OneWayThread(self.db, self.source, self.dest, \
@@ -167,7 +168,7 @@ class ContainerThread(threading.Thread):
         logger.debug('Joining thread2')
         self.thread2.join()
 
-        # TODO: shutdown dynamic iptables rules code here.
+        # TODO: shutdown dynamic iptables
 
         self.end_dynamic_firewall(rules_to_remove)
 

--- a/hpotter/plugins/ContainerThread.py
+++ b/hpotter/plugins/ContainerThread.py
@@ -105,7 +105,7 @@ class ContainerThread(threading.Thread):
         dest_rule = iptc.Rule()
         dest_rule.src = dest_ip
         dest_rule.dst = src_ip
-        dest_port.protocol = "tcp"
+        dest_rule.protocol = "tcp"
         dest_rule.create_target("ACCEPT")
         dest_match = dest_rule.create_match("tcp")
         dest_match.sport = dest_port

--- a/hpotter/plugins/ContainerThread.py
+++ b/hpotter/plugins/ContainerThread.py
@@ -88,11 +88,11 @@ class ContainerThread(threading.Thread):
         The returned array is used to shutdown the dynamic firewall by removing all of the created rules
         If the program crashes before the end_dynamic_firewall() call, the table will need to be cleared manually
 
-        :param src_ip: Attacker's IP
-        :param src_port: Attacker's port
-        :param dest_ip: Container's IP
-        :param dest_port: Container's Port
-        :return rule[]: Rule array returned for usage in end_dynamic_firewall()
+        :param src_ip: Attacker's IP string
+        :param src_port: Attacker's port string
+        :param dest_ip: Container's IP string
+        :param dest_port: Container's Port string
+        :return rule[]: Rule array returned for usage in start_dynamic_firewall() and end_dynamic_firewall()
         """
 
         src_rule = iptc.Rule()

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -11,10 +11,8 @@ class TestContainerThread(unittest.TestCase):
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"
-        mock = unittest.mock.Mock()
-        mock = ContainerThread()
 
-        result = ContainerThread.start_dynamic_firewall(mock, source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
 
         filter = iptc.Table(iptc.Table.FILTER)
         filter.flush()

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -11,9 +11,10 @@ class TestContainerThread(unittest.TestCase):
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"
+        mock = unittest.mock.Mock()
+        mock = ContainerThread()
 
-
-        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(mock, source_ip, source_port, destination_ip, destination_port)
 
         filter = iptc.Table(iptc.Table.FILTER)
         filter.flush()

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -1,45 +1,21 @@
 import unittest
+import iptc
 
 from hpotter.plugins.ContainerThread import ContainerThread
 
 class TestContainerThread(unittest.TestCase):
+    #   TODO: Encapsulate the changes made to the filter table so that the tests do not actually make changes to it
 
-    def test_TestDynamicFireWallSrc1(self):
-        source_ip = "142.56.0.1"
+    def test_TestDynamicFireWallRule1(self):
+        source_ip = "192.168.1.1"
         source_port = "8080"
-        destination_ip = "172.168.1.1"
+        destination_ip = "172.161.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
+
+        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+
+        filter = iptc.Table(iptc.Table.FILTER)
+        filter.flush()
 
         self.assertEqual(result[0].src, source_ip)
-
-    def test_TestDynamicFirewallDst1(self):
-        source_ip = "142.56.0.1"
-        source_port = "8080"
-        destination_ip = "172.168.1.1"
-        destination_port = "8081"
-
-        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
-
-        self.assertEqual(result[0].dst, destination_ip)
-
-    def test_DynamicFirewallSport1(self):
-        source_ip = "142.56.0.1"
-        source_port = "8080"
-        destination_ip = "172.168.1.1"
-        destination_port = "8081"
-
-        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
-
-        self.assertEqual(result[0].matches[0].sport, source_port)
-
-    def test_DynamicFirewallDport1(self):
-        source_ip = "142.56.0.1"
-        source_port = "8080"
-        destination_ip = "172.168.1.1"
-        destination_port = "8081"
-
-        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
-
-        self.assertEqual(result[0].matches[0].dport, destination_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -6,11 +6,13 @@ class TestContainerThread(unittest.TestCase):
 
     def test_TestDynamicFireWallRule1Src(self):
         source_ip = "192.168.1.1"
+        netmask = "255.255.255.255"     # When the net mask is not specified by the user, it defaults to this
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"
 
         result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)
+        expected_src = source_ip + "/" + netmask
 
-        self.assertEqual(result[0].src, source_ip)
+        self.assertEqual(result[0].src, expected_src)
         self.assertEqual(result[0].matches[0].sport, source_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -13,6 +13,9 @@ class TestContainerThread(unittest.TestCase):
 
         result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)[0]
         expected_src = source_ip + "/" + netmask
+        expected_dst = destination_ip + "/" + netmask
 
-        self.assertEqual(result[0].src, expected_src)
-        self.assertEqual(result[0].matches[0].sport, source_port)
+        self.assertEqual(result.src, expected_src)
+        self.assertEqual(result.matches[0].sport, source_port)
+        self.assertEqual(result.dst, expected_dst)
+        self.assertEqual(result.matches[0].dport, destination_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -1,0 +1,45 @@
+import unittest
+
+from hpotter.plugins.ContainerThread import ContainerThread
+
+class TestContainerThread(unittest.TestCase):
+
+    def test_TestDynamicFireWallSrc1(self):
+        source_ip = "142.56.0.1"
+        source_port = "8080"
+        destination_ip = "172.168.1.1"
+        destination_port = "8081"
+
+        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+
+        self.assertEqual(result[0].src, source_ip)
+
+    def test_TestDynamicFirewallDst1(self):
+        source_ip = "142.56.0.1"
+        source_port = "8080"
+        destination_ip = "172.168.1.1"
+        destination_port = "8081"
+
+        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+
+        self.assertEqual(result[0].dst, destination_ip)
+
+    def test_DynamicFirewallSport1(self):
+        source_ip = "142.56.0.1"
+        source_port = "8080"
+        destination_ip = "172.168.1.1"
+        destination_port = "8081"
+
+        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+
+        self.assertEqual(result[0].matches[0].sport, source_port)
+
+    def test_DynamicFirewallDport1(self):
+        source_ip = "142.56.0.1"
+        source_port = "8080"
+        destination_ip = "172.168.1.1"
+        destination_port = "8081"
+
+        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+
+        self.assertEqual(result[0].matches[0].dport, destination_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -4,7 +4,7 @@ from hpotter.plugins.ContainerThread import ContainerThread
 
 class TestContainerThread(unittest.TestCase):
 
-    def test_TestDynamicFireWallRule1(self):
+    def test_TestDynamicFirewallRule1(self):
         source_ip = "192.168.1.1"
         netmask = "255.255.255.255"     # When the subnet mask is not specified by the user, it defaults to this
         source_port = "8080"
@@ -12,10 +12,38 @@ class TestContainerThread(unittest.TestCase):
         destination_port = "8081"
 
         result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)[0]
-        expected_src = source_ip + "/" + netmask
-        expected_dst = destination_ip + "/" + netmask
+        real_src = source_ip + "/" + netmask
+        real_dst = destination_ip + "/" + netmask
 
-        self.assertEqual(result.src, expected_src)
+        self.assertEqual(result.src, real_src)
         self.assertEqual(result.matches[0].sport, source_port)
-        self.assertEqual(result.dst, expected_dst)
+        self.assertEqual(result.dst, real_dst)
         self.assertEqual(result.matches[0].dport, destination_port)
+        self.assertEqual(result.protocol, "tcp")
+
+    def test_TestDynamicFirewallRule2(self):
+        source_ip = "192.168.1.1"
+        netmask = "255.255.255.255"  # When the subnet mask is not specified by the user, it defaults to this
+        source_port = "8080"
+        destination_ip = "172.161.1.1"
+        destination_port = "8081"
+
+        result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)[1]
+        real_src = source_ip + "/" + netmask
+        real_dst = destination_ip + "/" + netmask
+
+        self.assertEqual(result.src, real_dst)
+        self.assertEqual(result.matches[0].sport, destination_port)
+        self.assertEqual(result.dst, real_src)
+        self.assertEqual(result.matches[0].dport, source_port)
+        self.assertEqual(result.protocol, "tcp")
+
+    # TODO: Since this rule inverts the destination there needs to be a way to make sure that the rule is inverted
+    # The actual destination address is not changed. Relevant lines in iptc.py [1111 - 1153]
+    '''
+    def test_TestDynamicFirewallRule3(self):
+        print("TODO")
+    '''
+
+
+

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -40,6 +40,6 @@ class TestContainerThread(unittest.TestCase):
         destination_ip = "172.168.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(self, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].matches[0].dport, destination_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -4,14 +4,14 @@ from hpotter.plugins.ContainerThread import ContainerThread
 
 class TestContainerThread(unittest.TestCase):
 
-    def test_TestDynamicFireWallRule1Src(self):
+    def test_TestDynamicFireWallRule1(self):
         source_ip = "192.168.1.1"
         netmask = "255.255.255.255"     # When the net mask is not specified by the user, it defaults to this
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)[0]
         expected_src = source_ip + "/" + netmask
 
         self.assertEqual(result[0].src, expected_src)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -6,7 +6,7 @@ class TestContainerThread(unittest.TestCase):
 
     def test_TestDynamicFireWallRule1(self):
         source_ip = "192.168.1.1"
-        netmask = "255.255.255.255"     # When the net mask is not specified by the user, it defaults to this
+        netmask = "255.255.255.255"     # When the subnet mask is not specified by the user, it defaults to this
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -10,7 +10,7 @@ class TestContainerThread(unittest.TestCase):
         destination_ip = "172.168.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].src, source_ip)
 
@@ -20,7 +20,7 @@ class TestContainerThread(unittest.TestCase):
         destination_ip = "172.168.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].dst, destination_ip)
 
@@ -30,7 +30,7 @@ class TestContainerThread(unittest.TestCase):
         destination_ip = "172.168.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].matches[0].sport, source_port)
 
@@ -40,6 +40,6 @@ class TestContainerThread(unittest.TestCase):
         destination_ip = "172.168.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(source_ip, source_port, destination_ip, destination_port)
+        result = ContainerThread.start_dynamic_firewall(self, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].matches[0].dport, destination_port)

--- a/hpotter/test/test_ContainerThread.py
+++ b/hpotter/test/test_ContainerThread.py
@@ -1,20 +1,16 @@
 import unittest
-import iptc
 
 from hpotter.plugins.ContainerThread import ContainerThread
 
 class TestContainerThread(unittest.TestCase):
-    #   TODO: Encapsulate the changes made to the filter table so that the tests do not actually make changes to it
 
-    def test_TestDynamicFireWallRule1(self):
+    def test_TestDynamicFireWallRule1Src(self):
         source_ip = "192.168.1.1"
         source_port = "8080"
         destination_ip = "172.161.1.1"
         destination_port = "8081"
 
-        result = ContainerThread.start_dynamic_firewall(self, source_ip, source_port, destination_ip, destination_port)
-
-        filter = iptc.Table(iptc.Table.FILTER)
-        filter.flush()
+        result = ContainerThread.create_rules(self, source_ip, source_port, destination_ip, destination_port)
 
         self.assertEqual(result[0].src, source_ip)
+        self.assertEqual(result[0].matches[0].sport, source_port)


### PR DESCRIPTION
Added code for dynamic firewalls in 3 different methods in ContainerThread.py

create_rule(), start_dynamic_firewall(), and end_dynamic_firewall().

Added some simple unit tests. More robust tests will need to be created
